### PR TITLE
Add backport for focal

### DIFF
--- a/backports/focal
+++ b/backports/focal
@@ -1,0 +1,26 @@
+#! /usr/bin/perl
+#
+# Hook for automatic backports.
+#
+# Target dist: Ubuntu Focal Fossa
+
+use warnings;
+use strict;
+use Carp;
+
+open(F, "debian/control") or croak;
+my $file;
+while (<F>) {
+  $file .= $_;
+}
+close(F);
+
+$file .= "\n";
+
+$file =~ s/ice34-slice/zeroc-ice-slice/g;
+$file =~ s/ice34-translators/zeroc-ice-compilers/g;
+$file =~ s/libzeroc-ice34-dev/libzeroc-ice-dev/g;
+
+open(F, ">debian/control") or croak;
+print F $file;
+close(F);


### PR DESCRIPTION
Not really a backport but that is the folder name. Copied from eoan.

mumble-voip/mumble#4170 mentioned testing in Ubuntu 20.04 but right now the snapshot PPA doesn't have a build for Focal Fossa.

This should allow for testing 1.3.1-rc1 on Ubuntu 20.04 

I ran ./ppagen.bash 1.3.1-rc1 focal 1 --dry-run --build from an Ubuntu 20.04 VM and it successfully created mumble-server_1.3.1-rc1-1~ppa1~focal1_amd64.deb 

